### PR TITLE
Correcting the path structure listed in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,12 +24,12 @@ packs/
         some_other_non_namespaced_private_model.rb # this works too
         my_domain/
           my_private_namespacd_model.rb
-      config/
-        initializers/ # Initializers can live in packs and load as expected
       controllers/
       views/
-      lib/
-        tasks/
+    config/
+      initializers/ # Initializers can live in packs and load as expected
+    lib/
+      tasks/
     spec/ # With stimpack, specs for a pack live next to the pack
       public/
         my_domain_spec.rb


### PR DESCRIPTION
The paths listed in the README imply that the `config/initializers` and `lib/tasks` folders should be placed within the `app` directory in the package's folder, when they should belong in the root of the package directory.  This PR corrects the spacing in the README and moves the lines down slightly to make the markdown more readable.