### PR TITLE
Add the ability to define routes per pack

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,17 @@ module MyCoolApp
 end
 ```
 
+### Splitting routes
+`stimpack` allows you to split your application routes for every pack. You just have to create a file describing your routes and then `draw` them in your root `config/routes.rb` file.
+
+```ruby
+# packs/my_domain/config/routes/my_domain.rb
+resources :my_resource
+
+# config/routes.rb
+draw(:my_domain)
+```
+
 ### Making your Package an Engine
 Add `engine: true` to your `package.yml` to make it an actual Rails engine:
 ```yml

--- a/lib/stimpack.rb
+++ b/lib/stimpack.rb
@@ -42,6 +42,7 @@ module Stimpack
     config
     config/locales
     config/initializers
+    config/routes
   )
 end
 


### PR DESCRIPTION
We'd like to keep routes in the pack they belong. In order to achieve that, we'll need to also add the `config/routes/` dir for each pack to the Rails paths.

This features is based on the Rails feature to [break up very large route file into multiple small ones](https://guides.rubyonrails.org/routing.html#breaking-up-very-large-route-file-into-multiple-small-ones).

We're not sure if this PR can affect the Engine setup, besides that, its usage is optional so it shouldn't impact anyone.

You can see an example of this feature implemented [here](https://github.com/rootstrap/rails-modular-monolith-with-ddd/pull/23).